### PR TITLE
Create shared base template and dark theme styling

### DIFF
--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -1,0 +1,168 @@
+:root {
+    --brand-primary: #6366f1;
+    --brand-primary-dark: #4f46e5;
+    --brand-accent: #a855f7;
+    --surface-base: rgba(15, 23, 42, 0.65);
+    --surface-elevated: rgba(30, 41, 59, 0.75);
+    --surface-border: rgba(148, 163, 184, 0.2);
+    --text-base: #e2e8f0;
+    --text-muted: #94a3b8;
+    --gradient-start: #0f172a;
+    --gradient-end: #1f2937;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    background: radial-gradient(circle at top, rgba(99, 102, 241, 0.2), transparent 45%),
+                radial-gradient(circle at bottom, rgba(168, 85, 247, 0.15), transparent 40%),
+                linear-gradient(160deg, var(--gradient-start), var(--gradient-end));
+    color: var(--text-base);
+    letter-spacing: 0.01em;
+}
+
+main .container {
+    max-width: 1140px;
+}
+
+.navbar,
+footer {
+    background-color: rgba(15, 23, 42, 0.8) !important;
+    backdrop-filter: blur(12px);
+}
+
+.navbar-brand {
+    color: var(--text-base);
+    font-weight: 600;
+    letter-spacing: 0.04em;
+}
+
+.navbar-brand:hover {
+    color: var(--brand-accent);
+}
+
+.navbar .nav-link {
+    color: var(--text-muted);
+    transition: color 0.2s ease, opacity 0.2s ease;
+}
+
+.navbar .nav-link:hover,
+.navbar .nav-link:focus {
+    color: var(--text-base);
+}
+
+.navbar .nav-link.active {
+    color: var(--brand-primary);
+    font-weight: 600;
+}
+
+.glass-panel {
+    background: var(--surface-elevated);
+    border: 1px solid var(--surface-border);
+    border-radius: 1.5rem;
+    backdrop-filter: blur(16px);
+    box-shadow: 0 20px 60px rgba(15, 23, 42, 0.35);
+}
+
+.card {
+    color: var(--text-base);
+}
+
+.page-title {
+    font-size: clamp(2rem, 4vw, 2.75rem);
+    font-weight: 700;
+    margin-bottom: 1rem;
+}
+
+.text-gradient {
+    background: linear-gradient(120deg, var(--brand-primary), var(--brand-accent));
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+
+.lead {
+    color: var(--text-muted) !important;
+}
+
+.btn-primary {
+    background: var(--brand-primary);
+    border-color: var(--brand-primary);
+    box-shadow: 0 10px 25px rgba(99, 102, 241, 0.25);
+}
+
+.btn-primary:hover,
+.btn-primary:focus {
+    background: var(--brand-primary-dark);
+    border-color: var(--brand-primary-dark);
+}
+
+.btn-outline-light {
+    color: var(--text-base);
+    border-color: rgba(226, 232, 240, 0.4);
+}
+
+.btn-outline-light:hover,
+.btn-outline-light:focus {
+    color: var(--brand-primary);
+    background: rgba(99, 102, 241, 0.1);
+    border-color: rgba(99, 102, 241, 0.4);
+}
+
+.placeholder {
+    background: rgba(15, 23, 42, 0.6);
+    border: 1px dashed rgba(148, 163, 184, 0.35);
+    color: var(--text-muted);
+}
+
+footer {
+    color: var(--text-muted);
+}
+
+footer a {
+    text-decoration: none;
+}
+
+footer a:hover {
+    color: var(--text-base);
+}
+
+@media (max-width: 767.98px) {
+    .navbar {
+        border-radius: 0;
+    }
+
+    .glass-panel {
+        border-radius: 1rem;
+    }
+}
+
+@media (prefers-color-scheme: light) {
+    :root {
+        --gradient-start: #f8fafc;
+        --gradient-end: #e2e8f0;
+        --surface-base: rgba(255, 255, 255, 0.75);
+        --surface-elevated: rgba(255, 255, 255, 0.85);
+        --text-base: #0f172a;
+        --text-muted: #475569;
+    }
+
+    body {
+        background: linear-gradient(160deg, #f8fafc, #e2e8f0);
+    }
+
+    .navbar,
+    footer {
+        background-color: rgba(255, 255, 255, 0.95) !important;
+    }
+
+    .navbar .nav-link.active {
+        color: var(--brand-primary-dark);
+    }
+
+    .glass-panel {
+        box-shadow: 0 15px 45px rgba(15, 23, 42, 0.12);
+    }
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="dark">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}City Explorer{% endblock %}</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/theme.css') }}">
+    {% block extra_head %}{% endblock %}
+</head>
+<body class="d-flex flex-column min-vh-100">
+    <header>
+        <nav class="navbar navbar-expand-lg navbar-dark bg-body shadow-sm border-bottom border-opacity-25 border-secondary">
+            <div class="container py-2">
+                <a class="navbar-brand fw-semibold" href="{{ url_for('index') }}">City Explorer</a>
+                <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav" aria-controls="mainNav" aria-expanded="false" aria-label="Toggle navigation">
+                    <span class="navbar-toggler-icon"></span>
+                </button>
+                <div class="collapse navbar-collapse" id="mainNav">
+                    {% set active_city = request.view_args['city_name'] if request.view_args and 'city_name' in request.view_args else default_city|default('featured') %}
+                    <ul class="navbar-nav ms-auto gap-lg-3">
+                        <li class="nav-item">
+                            <a class="nav-link {% if request.endpoint == 'index' %}active{% endif %}" href="{{ url_for('index') }}">Home</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link {% if request.endpoint and request.endpoint.startswith('map') %}active{% endif %}" href="{{ url_for('map') }}">Map</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link {% if request.endpoint and request.endpoint.startswith('stats') %}active{% endif %}" href="{{ url_for('stats') }}">Statistics</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link {% if request.endpoint and request.endpoint.startswith('city') %}active{% endif %}" href="{{ url_for('city', city_name=active_city) }}">City Profiles</a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </nav>
+    </header>
+
+    <main class="flex-grow-1">
+        <div class="container py-5">
+            {% block content %}{% endblock %}
+        </div>
+    </main>
+
+    <footer class="mt-auto py-4 border-top border-secondary border-opacity-25 bg-body-tertiary">
+        <div class="container d-flex flex-column flex-lg-row align-items-center justify-content-between gap-3">
+            <div class="text-secondary small">&copy; {{ current_year|default(2024) }} City Explorer. All rights reserved.</div>
+            <div class="d-flex gap-3 small">
+                <a class="link-light link-opacity-75-hover" href="#">Privacy</a>
+                <a class="link-light link-opacity-75-hover" href="#">Terms</a>
+                <a class="link-light link-opacity-75-hover" href="#">Support</a>
+            </div>
+        </div>
+    </footer>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+    {% block extra_scripts %}{% endblock %}
+</body>
+</html>

--- a/templates/city.html
+++ b/templates/city.html
@@ -1,0 +1,32 @@
+{% extends 'base.html' %}
+
+{% block title %}City Profile | City Explorer{% endblock %}
+
+{% block content %}
+<section class="py-4">
+    <h1 class="page-title">{{ city_name|default('Featured City') }}</h1>
+    <p class="lead text-secondary">Dive into the latest highlights, trends, and opportunities for this location.</p>
+    <div class="row g-4">
+        <div class="col-xl-4">
+            <div class="card glass-panel border-0 h-100">
+                <div class="card-body">
+                    <h2 class="h5 fw-semibold mb-3">At a glance</h2>
+                    <ul class="list-unstyled mb-0 text-secondary small">
+                        <li class="mb-2">Population: {{ population|default('—') }}</li>
+                        <li class="mb-2">Median age: {{ median_age|default('—') }}</li>
+                        <li>Key industry: {{ key_industry|default('—') }}</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div class="col-xl-8">
+            <div class="card glass-panel border-0 h-100">
+                <div class="card-body">
+                    <h2 class="h5 fw-semibold mb-3">Narrative</h2>
+                    <p class="text-secondary small mb-0">{{ narrative|default('Provide contextual insights and planning notes for this city here. Summaries and bullet points will be styled consistently across the site.') }}</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,30 @@
+{% extends 'base.html' %}
+
+{% block title %}Home | City Explorer{% endblock %}
+
+{% block content %}
+<section class="py-4">
+    <div class="row g-4 align-items-center">
+        <div class="col-lg-7">
+            <h1 class="display-5 fw-bold text-gradient">Welcome to City Explorer</h1>
+            <p class="lead text-secondary">Discover interactive maps, analyze statistics, and dive deep into the unique character of every city we cover.</p>
+            <div class="d-flex flex-wrap gap-3">
+                <a class="btn btn-primary btn-lg" href="{{ url_for('map') }}">View Interactive Map</a>
+                <a class="btn btn-outline-light btn-lg" href="{{ url_for('stats') }}">See City Stats</a>
+            </div>
+        </div>
+        <div class="col-lg-5">
+            <div class="card glass-panel h-100 border-0">
+                <div class="card-body">
+                    <h2 class="h4 fw-semibold mb-3">What's new</h2>
+                    <ul class="list-unstyled mb-0 small text-secondary">
+                        <li class="mb-2">Live data updates every hour.</li>
+                        <li class="mb-2">Optimized for dark-mode viewing on every device.</li>
+                        <li>Shareable city profiles tailored for planners and researchers.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+{% endblock %}

--- a/templates/map.html
+++ b/templates/map.html
@@ -1,0 +1,19 @@
+{% extends 'base.html' %}
+
+{% block title %}Interactive Map | City Explorer{% endblock %}
+
+{% block content %}
+<section class="py-4">
+    <h1 class="page-title">Interactive Map</h1>
+    <p class="lead text-secondary">Zoom into neighborhoods, switch between layers, and explore key metrics visually.</p>
+    <div class="card glass-panel border-0">
+        <div class="card-body">
+            <div class="ratio ratio-16x9">
+                <div class="placeholder rounded-4 d-flex align-items-center justify-content-center">
+                    <span class="text-secondary">Map visualization renders here.</span>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+{% endblock %}

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -1,0 +1,36 @@
+{% extends 'base.html' %}
+
+{% block title %}City Statistics | City Explorer{% endblock %}
+
+{% block content %}
+<section class="py-4">
+    <h1 class="page-title">City Statistics</h1>
+    <p class="lead text-secondary">Compare demographic, economic, and sustainability metrics across regions.</p>
+    <div class="row g-4">
+        <div class="col-lg-6">
+            <div class="card glass-panel border-0 h-100">
+                <div class="card-body">
+                    <h2 class="h5 fw-semibold mb-3">Key insights</h2>
+                    <ul class="list-unstyled mb-0 text-secondary small">
+                        <li class="mb-2">Population growth trends over the past decade.</li>
+                        <li class="mb-2">Infrastructure investment per capita.</li>
+                        <li>Air quality improvements compared to regional averages.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div class="col-lg-6">
+            <div class="card glass-panel border-0 h-100">
+                <div class="card-body">
+                    <h2 class="h5 fw-semibold mb-3">Download reports</h2>
+                    <p class="text-secondary small">Export the latest datasets in CSV or PDF to integrate with your own models.</p>
+                    <div class="d-flex flex-wrap gap-2">
+                        <a class="btn btn-primary btn-sm" href="#">Download CSV</a>
+                        <a class="btn btn-outline-light btn-sm" href="#">Download PDF</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a reusable base layout with Bootstrap 5, navigation, and a shared footer
- refactor the index, map, stats, and city templates to extend the base template
- add a custom dark-friendly theme stylesheet for consistent spacing and typography

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ceed0d120083218f223796aa7503e2